### PR TITLE
Use Release.Name in python example in NOTES.txt. (#89)

### DIFF
--- a/helm/afm/templates/NOTES.txt
+++ b/helm/afm/templates/NOTES.txt
@@ -7,7 +7,7 @@ import pyarrow.flight as fl
 import pandas as pd
 
 # Create a Flight client
-client = fl.connect("grpc://{{ include "arrow-flight-module.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:80")
+client = fl.connect("grpc://{{ .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:80")
 
 # Prepare the request
 request = {


### PR DESCRIPTION
This PR fixes the name of the service printed in the python example to be the same as the release name.
Closes #89 